### PR TITLE
vcpkg fixes: separate vcpkg-tool and allow manifest mode to work

### DIFF
--- a/pkgs/development/tools/vcpkg-tool/default.nix
+++ b/pkgs/development/tools/vcpkg-tool/default.nix
@@ -12,7 +12,6 @@
 , git
 , gnumake
 , gzip
-, jq
 , lib
 , makeWrapper
 , meson
@@ -20,9 +19,7 @@
 , perl
 , pkg-config
 , python3
-, runtimeShell
 , stdenv
-, vcpkg-tool
 , zip
 , zstd
 }:

--- a/pkgs/development/tools/vcpkg-tool/default.nix
+++ b/pkgs/development/tools/vcpkg-tool/default.nix
@@ -1,0 +1,88 @@
+{ autoconf
+, automake
+, bash
+, cacert
+, cmake
+, cmakerc
+, coreutils
+, curl
+, fetchFromGitHub
+, fmt
+, gcc
+, git
+, gnumake
+, gzip
+, jq
+, lib
+, makeWrapper
+, meson
+, ninja
+, perl
+, pkg-config
+, python3
+, runtimeShell
+, stdenv
+, vcpkg-tool
+, zip
+, zstd
+}:
+let
+  # These are the most common binaries used by vcpkg
+  # If a port requires a binary that is not in this list,
+  # it can be added by an overlay
+  runtimeDeps = [
+    autoconf
+    automake
+    bash
+    cacert
+    coreutils
+    curl
+    cmake
+    gcc
+    git
+    gnumake
+    gzip
+    meson
+    ninja
+    perl
+    pkg-config
+    python3
+    zip
+    zstd
+  ];
+in
+stdenv.mkDerivation {
+  pname = "vcpkg-tool";
+  version = "2023-06-22";
+
+  src = fetchFromGitHub {
+    owner = "microsoft";
+    repo = "vcpkg-tool";
+    rev = "2023-06-22";
+    hash = "sha256-/Bn2TW6JWU676NzsQdtC6G513MtRHblLVP0pK5jyCWc=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    cmakerc
+    fmt
+    ninja
+  ];
+
+  cmakeFlags = [
+    "-DVCPKG_DEPENDENCY_EXTERNAL_FMT=ON"
+    "-DVCPKG_DEPENDENCY_CMAKERC=ON"
+  ];
+
+  postFixup = ''
+    # add the runtime dependencies to the PATH
+    wrapProgram $out/bin/vcpkg --set PATH ${lib.makeBinPath runtimeDeps}
+  '';
+
+  meta = with lib; {
+    description = "Components of microsoft/vcpkg's binary.";
+    homepage = "https://github.com/microsoft/vcpkg-tool";
+    license = licenses.mit;
+    maintainers = with maintainers; [ guekka gracicot ];
+  };
+}

--- a/pkgs/development/tools/vcpkg-tool/default.nix
+++ b/pkgs/development/tools/vcpkg-tool/default.nix
@@ -64,6 +64,7 @@ stdenv.mkDerivation {
     cmakerc
     fmt
     ninja
+    makeWrapper
   ];
 
   cmakeFlags = [

--- a/pkgs/development/tools/vcpkg/default.nix
+++ b/pkgs/development/tools/vcpkg/default.nix
@@ -43,7 +43,6 @@ stdenv.mkDerivation rec {
     fi
 
     if [[ ! -f "$vcpkg_root_path/vcpkg.disable-metrics" ]]; then
-      touch $out/share/vcpkg/vcpkg.disable-metrics
       touch $vcpkg_root_path/vcpkg.disable-metrics
     fi
     

--- a/pkgs/development/tools/vcpkg/default.nix
+++ b/pkgs/development/tools/vcpkg/default.nix
@@ -3,7 +3,6 @@
 , stdenv
 , jq
 , runtimeShell
-, callPackage
 , lib
 , vcpkg-tool
 }:
@@ -19,9 +18,6 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [
-    cmake
-    cmakerc
-    fmt
     makeWrapper
   ];
 
@@ -85,21 +81,11 @@ stdenv.mkDerivation rec {
   ];
 
   postInstall = ''
-    mkdir -p $out/share/vcpkg
-
-    cp --preserve=mode -r ${src}/{docs,ports,scripts,triplets,versions,LICENSE.txt} $out/share/vcpkg
-
-    # we preserve the original vcpkg binary, and replace it with a wrapper script
-    mv $out/bin/vcpkg $out/share/vcpkg/vcpkg
+    mkdir -p $out/bin $out/share/vcpkg/scripts/buildsystems
+    cp --preserve=mode -r ${src}/{docs,ports,triplets,scripts,.vcpkg-root,versions,LICENSE.txt} $out/share/vcpkg/
     cp $vcpkgScriptPath $out/bin/vcpkg
     chmod +x $out/bin/vcpkg
-
-    mkdir -p $out/bin
-    mkdir -p $out/share/vcpkg/scripts/buildsystems
-    cp --preserve=mode -r ${src}/{docs,ports,triplets,scripts,.vcpkg-root,versions,LICENSE.txt} $out/share/vcpkg
-    cp $vcpkgScriptPath $out/bin/vcpkg
     ln -s $out/bin/vcpkg $out/share/vcpkg/vcpkg
-    chmod +x $out/bin/vcpkg
     touch $out/share/vcpkg/vcpkg.disable-metrics
   '';
 

--- a/pkgs/development/tools/vcpkg/default.nix
+++ b/pkgs/development/tools/vcpkg/default.nix
@@ -48,6 +48,7 @@ stdenv.mkDerivation rec {
 
     if [[ ! -f "$vcpkg_root_path/vcpkg.disable-metrics" ]]; then
       touch $out/share/vcpkg/vcpkg.disable-metrics
+      touch $vcpkg_root_path/vcpkg.disable-metrics
     fi
     
     # Always take control of the root by linking current triplets

--- a/pkgs/development/tools/vcpkg/default.nix
+++ b/pkgs/development/tools/vcpkg/default.nix
@@ -32,7 +32,7 @@ stdenv.mkDerivation rec {
     in
     ''
     #!${runtimeShell}
-    vcpkg_root_path="$HOME/.vcpkg/root/"
+    vcpkg_root_path="$HOME/.local/share/vcpkg/root/"
 
     if [[ ! -d "$vcpkg_root_path" ]]; then
       mkdir -p "$vcpkg_root_path"

--- a/pkgs/development/tools/vcpkg/default.nix
+++ b/pkgs/development/tools/vcpkg/default.nix
@@ -36,14 +36,8 @@ stdenv.mkDerivation rec {
 
     if [[ ! -d "$vcpkg_root_path" ]]; then
       mkdir -p "$vcpkg_root_path"
-    fi
-    
-    if [[ ! -f "$vcpkg_root_path/.vcpkg-root" ]]; then
       touch "$vcpkg_root_path/.vcpkg-root"
-    fi
-
-    if [[ ! -f "$vcpkg_root_path/vcpkg.disable-metrics" ]]; then
-      touch $vcpkg_root_path/vcpkg.disable-metrics
+      touch "$vcpkg_root_path/vcpkg.disable-metrics"
     fi
     
     # Always take control of the root by linking current triplets

--- a/pkgs/development/tools/vcpkg/patches/remove-root-argument.diff
+++ b/pkgs/development/tools/vcpkg/patches/remove-root-argument.diff
@@ -1,0 +1,11 @@
+index 4ee6740a2..c5a79d191 100644
+--- a/scripts/buildsystems/vcpkg.cmake
++++ b/scripts/buildsystems/vcpkg.cmake
+@@ -506,7 +506,6 @@ if(VCPKG_MANIFEST_MODE AND VCPKG_MANIFEST_INSTALL AND NOT Z_VCPKG_CMAKE_IN_TRY_C
+         execute_process(
+             COMMAND "${Z_VCPKG_EXECUTABLE}" install
+                 --triplet "${VCPKG_TARGET_TRIPLET}"
+-                --vcpkg-root "${Z_VCPKG_ROOT_DIR}"
+                 "--x-wait-for-lock"
+                 "--x-manifest-root=${VCPKG_MANIFEST_DIR}"
+                 "--x-install-root=${_VCPKG_INSTALLED_DIR}"

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -690,6 +690,8 @@ with pkgs;
 
   sea-orm-cli = callPackage ../development/tools/sea-orm-cli { };
 
+  vcpkg-tool = callPackage ../development/tools/vcpkg-tool { };
+
   vcpkg = callPackage ../development/tools/vcpkg { fmt = fmt_10; };
 
   r3ctl = qt5.callPackage ../tools/misc/r3ctl { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -690,9 +690,9 @@ with pkgs;
 
   sea-orm-cli = callPackage ../development/tools/sea-orm-cli { };
 
-  vcpkg-tool = callPackage ../development/tools/vcpkg-tool { };
+  vcpkg-tool = callPackage ../development/tools/vcpkg-tool { fmt = fmt_10; };
 
-  vcpkg = callPackage ../development/tools/vcpkg { fmt = fmt_10; };
+  vcpkg = callPackage ../development/tools/vcpkg {  };
 
   r3ctl = qt5.callPackage ../tools/misc/r3ctl { };
 


### PR DESCRIPTION
###### Description of changes

This MR separate vcpkg-tool so that vpckg always run the wrapper script. This enables manifest mode to work correctly.

###### Things done

Nothing ;-;

This is a MR on your MR, I'm not so good with nix and I don't know how to test packages from a local nixpkgs rapidly.

I have a nix shell file that called a local package nix file, and this is how I tested.